### PR TITLE
Update RNMeasureText.podspec

### DIFF
--- a/ios/RNMeasureText.m
+++ b/ios/RNMeasureText.m
@@ -87,6 +87,9 @@ RCT_EXPORT_METHOD(measure:(NSDictionary *)options
 }
 
 - (UIFont *)getFont:(NSString *)fontFamily size:(CGFloat)fontSize weight:(NSString*)fontWeight {
+    if (fontWeight == nil) {
+        fontWeight = @"normal";
+    };
     return fontFamily == nil ?
         [RCTConvert UIFont:@{@"fontWeight": fontWeight, @"fontSize": [NSNumber numberWithFloat:fontSize]}] :
         [RCTConvert UIFont:@{@"fontFamily": fontFamily, @"fontSize": [NSNumber numberWithFloat:fontSize], @"fontWeight": fontWeight}];

--- a/ios/RNMeasureText.podspec
+++ b/ios/RNMeasureText.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/author/RNMeasureText.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/airamrguez/react-native-measure-text.git", :tag => "master" }
   s.source_files  = "RNMeasureText/**/*.{h,m}"
   s.requires_arc = true
 

--- a/ios/RNMeasureText.podspec
+++ b/ios/RNMeasureText.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNMeasureText
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/airamrguez/react-native-measure-text"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
Fix a validation error

update:

Corrects an error "[__NSPlaceholderDictionary initWithObjects:forKeys:count:] attempt to insert nil object from objects[0]" when fontWeight is not specified.